### PR TITLE
Fix syntax error on Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This gem correctly configures Rails for [CloudFlare](https://www.cloudflare.com)
 Add this line to your application's `Gemfile`:
 
 ```ruby
-group :production
+group :production do
   # or :staging or :beta or whatever environments you are using cloudflare in.
   # you probably don't want this for :test or :development
   gem 'cloudflare-rails'


### PR DESCRIPTION
Instructions on README about Gemfile has syntax error. This update fixes the README.