### PR TITLE
Fix ActionDispatch::Request.ip

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,8 +18,8 @@ if ENV['RACK_ATTACK']
   require 'rack/attack'
 end
 
-require 'cloudflare/rails'
 require 'rspec/rails'
+require 'cloudflare/rails'
 require 'webmock/rspec'
 
 RSpec.configure do |config|


### PR DESCRIPTION
Since `Rack::Request::Helpers` is usually included in `ActionDispatch::Request` _before_ cloudflare/rails is required,
`request.ip` is not likely to get patched in the context of a rails controller.

~Checking the included modules of every defined constant might be overkill, but it should fix things for any other middleware that includes `Rack::Request::Helpers`.~

Edit: This has been changed to check only the most common classes that include Rack's request helpers.

I updated the tests to include rspec/rails before cloudflare/rails since that is sufficient to show the failure without the fix.