### PR TITLE
rack-attack must be declared in your Gemfile before cloudflare-rails 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ And then execute:
 
     $ bundle
 
+If you are using [rack-attack](https://github.com/rack/rack-attack), this gem will ensure that `request.remote_ip` and `request.ip` are defined correctly in `Rack::Attack::Request`, however, you *must* declare `rack-attack` in your Gemfile before `cloudflare-rails`. For example:
+
+
+```ruby
+group :production do
+  gem 'rack-attack'
+  gem 'cloudflare-rails'
+end
+```
+
 ## Problem
 
 Using Cloudflare means it's hard to identify the IP address of incoming requests since all requests are proxied through Cloudflare's infrastructure. Cloudflare provides a [CF-Connecting-IP](https://support.cloudflare.com/hc/en-us/articles/200170986-How-does-Cloudflare-handle-HTTP-Request-headers-) header which can be used to identify the originating IP address of a request. However, this header alone doesn't verify a request is legitimate. If an attacker has found the actual IP address of your server they could spoof this header and masquerade as legitimate traffic. 


### PR DESCRIPTION
I ran into this issue today and spent way too long trying to work out why the IP address was still the IP of a Cloudflare server in rack-attack. I hadn't considered this possibilty because we have rubocop configured to check gems are ordered alphabetically in our Gemfile :facepalm:  Hopefully this saves someone else some time in the future.

This change just updates the readme to make it clear that if you are using rack-attack, you must declare it in your Gemfile before cloudflare-rails.

Gemfile with cloudflare-rails declared first
```
gem 'cloudflare-rails'
gem 'rack-attack'
```
The patch is not applied:
```
irb(main):001:0>  Rack::Attack::Request.new({}).method(:trusted_proxy?).source_location
=> ["/home/james/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rack-2.2.3/lib/rack/request.rb", 527]
```

Gemfile with rack-attack declared first:
```
gem 'rack-attack'
gem 'cloudflare-rails'
```

The patch is applied:
```
irb(main):001:0> Rack::Attack::Request.new({}).method(:trusted_proxy?).source_location
=> ["/home/james/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/cloudflare-rails-0.6.0/lib/cloudflare/rails/railtie.rb", 9]
```