### PR TITLE
Add require time core extensions

### DIFF
--- a/lib/cloudflare/rails/railtie.rb
+++ b/lib/cloudflare/rails/railtie.rb
@@ -1,3 +1,4 @@
+require "active_support/core_ext/integer/time"
 require "httparty"
 
 module Cloudflare


### PR DESCRIPTION
**Rails** 6.1.1
**Ruby** ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin19]

Starting rails server failure: 

`gems/ruby-2.7.2/gems/cloudflare-rails-1.1.0/lib/cloudflare/rails/railtie.rb:61:in `<class:Railtie>': undefined method `hours' for 12:Integer (NoMethodError)`

It's related to [rails issue](https://github.com/rails/rails/issues/37391) and there is the [fix for rails](https://github.com/rails/rails/pull/39059/files)