### PR TITLE
Handle invalid IP addresses better

### DIFF
--- a/lib/cloudflare/rails/railtie.rb
+++ b/lib/cloudflare/rails/railtie.rb
@@ -7,7 +7,13 @@ module Cloudflare
       # correct inside of rack and rails
       module CheckTrustedProxies
         def trusted_proxy?(ip)
-          ::Rails.application.config.cloudflare.ips.any? { |proxy| proxy === ip } || super
+          matching = ::Rails.application.config.cloudflare.ips.any? do |proxy|
+            begin
+              proxy === ip
+            rescue IPAddr::InvalidAddressError
+            end
+          end
+          matching || super
         end
       end
 

--- a/spec/cloudflare/rails_spec.rb
+++ b/spec/cloudflare/rails_spec.rb
@@ -235,6 +235,14 @@ describe Cloudflare::Rails do
 
               it_behaves_like "it gets the correct ip address from rack"
             end
+
+            context 'with an invalid ip' do
+              let(:base_ip) { "not-an-ip.test,122.175.218.25" }
+              let(:env) { cf_env }
+              let(:expected_ip) { "122.175.218.25" }
+
+              it_behaves_like "it gets the correct ip address from rack"
+            end
           end
 
           describe "##{m}", type: :controller do
@@ -277,6 +285,14 @@ describe Cloudflare::Rails do
             context 'with a non-cloudflare ip and a local proxy' do
               let(:env) { non_cf_proxy_env }
               let(:expected_ip) { non_cf_ip }
+
+              it_behaves_like "it gets the correct ip address from rails"
+            end
+
+            context 'with an invalid ip' do
+              let(:base_ip) { "not-an-ip.test,122.175.218.25" }
+              let(:env) { cf_env }
+              let(:expected_ip) { "122.175.218.25" }
 
               it_behaves_like "it gets the correct ip address from rails"
             end


### PR DESCRIPTION
We're seeing a lot of errors caused by security scanners that set completely invalid values in the `X-Forwarded-For` header, including `cache.example.com`, a myriad of `.onion` addresses and almost anything else you can imagine.

This PR rescues and swallows `IPAddr::InvalidAddressError` exceptions in the `trusted_proxy?` check so we can continue processing the list.

All the tests pass, I'd love to hear your thoughts to see if I missed something or if this opens us up to some other unseen abuse vector?