### PR TITLE
Skip fetching and caching of Cloudflare ip address when Rails::Console is defined or when ENV['DISABLE_CLOUDFLARE_RAILS] is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0-beta.0] - 12-10-24
+- Skip fetching and caching of Cloudflare ip address when Rails::Console is defined or when ENV['DISABLE_CLOUDFLARE_RAILS] is set
+
 ## [2.3.0] - 2021-10-22
 -  Better handling of malformed IP addresses (https://github.com/modosc/cloudflare-rails/pull/49)
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ config.cloudflare.expires_in = 12.hours # default value
 config.cloudflare.timeout = 5.seconds # default value
 ```
 
+`cloudflare-rails` automatically fetches IP address and stores them in your cache when your Rails app is initialized. Sometimes you may want to skip this behavior (in CI/build, for instance). To bypass it, set `DISABLE_CLOUDFLARE_RAILS` in your environment. Fetching/storing is also bypassed in `Rails::Console` sessions.
+
 ## Alternatives
 
 [actionpack-cloudflare](https://github.com/customink/actionpack-cloudflare) simpler approach using the `CF-Connecting-IP` header.

--- a/cloudflare-rails.gemspec
+++ b/cloudflare-rails.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rack-attack", "~> 6.5.0"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "appraisal"
+  spec.add_development_dependency "climate_control"
 
   spec.add_dependency "railties", ">= 5.2", "< 7.1.0"
   spec.add_dependency "activesupport", ">= 5.2", "< 7.1.0"

--- a/lib/cloudflare/rails/railtie.rb
+++ b/lib/cloudflare/rails/railtie.rb
@@ -55,6 +55,10 @@ module Cloudflare
             fetch IPS_V4_URL
           end
 
+          def should_skip?
+            defined?(::Rails::Console) || ENV.key?('DISABLE_CLOUDFLARE_RAILS')
+          end
+
           def fetch(url)
             uri = URI("#{BASE_URL}#{url}")
 
@@ -75,6 +79,7 @@ module Cloudflare
           end
 
           def fetch_with_cache(type)
+            return if should_skip?
             ::Rails.cache.fetch("cloudflare-rails:#{type}", expires_in: ::Rails.application.config.cloudflare.expires_in) do
               send type
             end

--- a/lib/cloudflare/rails/version.rb
+++ b/lib/cloudflare/rails/version.rb
@@ -1,5 +1,5 @@
 module Cloudflare
   module Rails
-    VERSION = "2.3.0".freeze
+    VERSION = "2.4.0-beta.0".freeze
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,8 @@ if ENV['RACK_ATTACK'] == 'last'
   require 'rack/attack'
 end
 
+require 'climate_control'
+
 RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = false
 end


### PR DESCRIPTION
available as [2.4.0.pre.beta0](https://rubygems.org/gems/cloudflare-rails/versions/2.4.0.pre.beta.0)