### PR TITLE
Add trailing slashes to reflect Cloudflare API URLs

### DIFF
--- a/lib/cloudflare/rails/railtie.rb
+++ b/lib/cloudflare/rails/railtie.rb
@@ -43,8 +43,8 @@ module Cloudflare
         end
 
         BASE_URL = 'https://www.cloudflare.com'.freeze
-        IPS_V4_URL = '/ips-v4'.freeze
-        IPS_V6_URL = '/ips-v6'.freeze
+        IPS_V4_URL = '/ips-v4/'.freeze
+        IPS_V6_URL = '/ips-v6/'.freeze
 
         class << self
           def ips_v6

--- a/spec/cloudflare/rails_spec.rb
+++ b/spec/cloudflare/rails_spec.rb
@@ -66,10 +66,10 @@ describe Cloudflare::Rails do
           end
         end
 
-        stub_request(:get, "https://www.cloudflare.com/ips-v4").
+        stub_request(:get, "https://www.cloudflare.com/ips-v4/").
           to_return(status: ips_v4_status, body: ips_v4_body)
 
-        stub_request(:get, "https://www.cloudflare.com/ips-v6").
+        stub_request(:get, "https://www.cloudflare.com/ips-v6/").
           to_return(status: ips_v6_status, body: ips_v6_body)
       end
 


### PR DESCRIPTION
It seems that Cloudflare recently changed their API list URLs such that
they now end with a slash. The old paths have a permanent redirect,
which the gem doesn't follow. This results in a silent failure and the
IP list being empty when querying
`Rails.application.config.cloudflare.ips`.

This change adds the trailing slash to get both requests working again.
