### PR TITLE
Switch to a supported CircleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/ruby:2.7.3
+      - image: cimg/ruby:2.7
 
     working_directory: ~/repo
 


### PR DESCRIPTION
CircleCI deprecated the 'circleci/ruby' images in favor of 'cimg/ruby'.  This PR switches the image used in CI to one from this current generation.

See [here](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) for information on the change.