### PR TITLE
Take open_timeout in consideration

### DIFF
--- a/lib/cloudflare/rails/railtie.rb
+++ b/lib/cloudflare/rails/railtie.rb
@@ -61,7 +61,8 @@ module Cloudflare
             resp = Net::HTTP.start(uri.host,
                                    uri.port,
                                    use_ssl: true,
-                                   read_timeout: ::Rails.application.config.cloudflare.timeout) do |http|
+                                   read_timeout: ::Rails.application.config.cloudflare.timeout,
+                                   open_timeout: ::Rails.application.config.cloudflare.timeout) do |http|
               req = Net::HTTP::Get.new(uri)
 
               http.request(req)


### PR DESCRIPTION
When Cloudflare is unaccessible (e.g., blocked by China GFW or Cloudflare is down), the requests are blocked for `open_timeout` (default 60 seconds in Net::HTTP) before failed, but it is not configurable in `cloudflare-ips`.