### PR TITLE
Fix support for hard-coded IPs specified via `config.cloudflare.ips`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Using Cloudflare means it's hard to identify the IP address of incoming requests
 `cloudflare-rails` mitigates this attack by checking that the originating ip address of any incoming connection is from one of Cloudflare's ip address ranges. If so, the incoming `X-Forwarded-For` header is trusted and used as the ip address provided to `rack` and `rails` (via `request.ip` and `request.remote_ip`). If the incoming connection does not originate from a Cloudflare server then the `X-Forwarded-For` header is ignored and the actual remote ip address is used.
 
 ## Usage
-This code will fetch CloudFlare's current [IPv4](https://www.cloudflare.com/ips-v4) and [IPv6](https://www.cloudflare.com/ips-v6) lists, store them in `Rails.cache`, and add them to `config.cloudflare.ips`. The `X-Forwarded-For` header will then be trusted only from those ip addresses.
+This code will fetch CloudFlare's current [IPv4](https://www.cloudflare.com/ips-v4) and [IPv6](https://www.cloudflare.com/ips-v6) lists, add any hard-coded values specified by `config.cloudflare.ips`, and store the resulting list in `Rails.cache`. The `X-Forwarded-For` header will then be trusted only from those ip addresses.
 
 You can configure the HTTP `timeout` and `expires_in` cache parameters inside of your rails config:
 ```ruby

--- a/lib/cloudflare/rails/railtie.rb
+++ b/lib/cloudflare/rails/railtie.rb
@@ -74,6 +74,12 @@ module Cloudflare
             end
           end
 
+          def custom_config_ips
+            return [] unless ::Rails.application.config.cloudflare.ips
+
+            ::Rails.application.config.cloudflare.ips.map { |ip| IPAddr.new ip }
+          end
+
           def fetch_with_cache(type)
             ::Rails.cache.fetch("cloudflare-rails:#{type}", expires_in: ::Rails.application.config.cloudflare.expires_in) do
               send type
@@ -82,7 +88,7 @@ module Cloudflare
 
           def cloudflare_ips(refresh: false)
             @ips = nil if refresh
-            @ips ||= (Importer.fetch_with_cache(:ips_v4) + Importer.fetch_with_cache(:ips_v6)).freeze
+            @ips ||= (Importer.custom_config_ips + Importer.fetch_with_cache(:ips_v4) + Importer.fetch_with_cache(:ips_v6)).freeze
           rescue StandardError => e
             ::Rails.logger.error(e)
             []

--- a/spec/cloudflare/rails_spec.rb
+++ b/spec/cloudflare/rails_spec.rb
@@ -146,7 +146,7 @@ describe Cloudflare::Rails do
         }
         let(:cf_custom_config_env) {{
           "HTTP_X_FORWARDED_FOR" => "#{base_ip}, #{cf_ip_from_config}",
-          'REMOTE_ADDR' => cf_ip,
+          'REMOTE_ADDR' => cf_ip_from_config,
         }
         }
         let(:non_cf_env) {{


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/modosc/cloudflare-rails/pull/52. Namely, `config.cloudflare.ips` were not being processed correctly, so if your configuration tried to include a manually-specified list of Cloudflare IPs (e.g. as a hard-coded backup in case the Cloudflare API has an outage), those manually-specified IPs were simply ignored.