### PR TITLE
properly scope railtie initializer

### DIFF
--- a/lib/cloudflare/rails/railtie.rb
+++ b/lib/cloudflare/rails/railtie.rb
@@ -100,7 +100,7 @@ module Cloudflare
         app.config.cloudflare.reverse_merge! DEFAULTS
       end
 
-      initializer "my_railtie.configure_rails_initialization" do
+      initializer "cloudflare_rails.configure_rails_initialization" do
         Rack::Request::Helpers.prepend CheckTrustedProxies
 
         ObjectSpace.each_object(Class).


### PR DESCRIPTION
Thanks for the awesome gem! I noticed while digging through the source that the initializer had "my_railtie" in its name. So I changed it to "cloudflare_rails".