### PR TITLE
use ips from config in failure cases

### DIFF
--- a/lib/cloudflare/rails/railtie.rb
+++ b/lib/cloudflare/rails/railtie.rb
@@ -83,7 +83,7 @@ module Cloudflare
             @ips ||= (Importer.fetch_with_cache(:ips_v4) + Importer.fetch_with_cache(:ips_v6)).freeze
           rescue StandardError => e
             ::Rails.logger.error(e)
-            []
+            ::Rails.application.config.cloudflare.ips
           end
         end
       end

--- a/spec/cloudflare/rails_spec.rb
+++ b/spec/cloudflare/rails_spec.rb
@@ -54,7 +54,7 @@ describe Cloudflare::Rails do
         EOM
       end
 
-      let(:default_ips) { ips_v4_body.split("\n") + ips_v6_body.split("\n") }
+      let(:default_ips) { (ips_v4_body.split("\n") + ips_v6_body.split("\n")).map { |ip| IPAddr.new ip } }
       let(:ips_v4_status) { 200 }
       let(:ips_v6_status) { 200 }
 

--- a/spec/cloudflare/rails_spec.rb
+++ b/spec/cloudflare/rails_spec.rb
@@ -54,6 +54,7 @@ describe Cloudflare::Rails do
         EOM
       end
 
+      let(:default_ips) { ips_v4_body.split("\n") + ips_v6_body.split("\n") }
       let(:ips_v4_status) { 200 }
       let(:ips_v6_status) { 200 }
 
@@ -101,6 +102,12 @@ describe Cloudflare::Rails do
           rails_app.initialize!
           expect(Cloudflare::Rails::Railtie::Importer.cloudflare_ips(refresh: true)).to be_blank
         end
+
+        it "returns the default configuration" do
+          rails_app.initialize!
+          ::Rails.application.config.cloudflare.ips = default_ips
+          expect(Cloudflare::Rails::Railtie::Importer.cloudflare_ips(refresh: true)).to eq(default_ips)
+        end
       end
 
       describe "with invalid bodies" do
@@ -111,6 +118,12 @@ describe Cloudflare::Rails do
           expect_any_instance_of(Logger).to receive(:error).once.and_call_original
           rails_app.initialize!
           expect(Cloudflare::Rails::Railtie::Importer.cloudflare_ips(refresh: true)).to be_blank
+        end
+
+        it "returns the default configuration" do
+          rails_app.initialize!
+          ::Rails.application.config.cloudflare.ips = default_ips
+          expect(Cloudflare::Rails::Railtie::Importer.cloudflare_ips(refresh: true)).to eq(default_ips)
         end
       end
 

--- a/spec/cloudflare/rails_spec.rb
+++ b/spec/cloudflare/rails_spec.rb
@@ -54,7 +54,7 @@ describe Cloudflare::Rails do
         EOM
       end
 
-      let(:default_ips) { (ips_v4_body.split("\n") + ips_v6_body.split("\n")).map { |ip| IPAddr.new ip } }
+      let(:default_ips) { [IPAddr.new("173.245.48.0/20"), IPAddr.new("2400:cb00::/32")] }
       let(:ips_v4_status) { 200 }
       let(:ips_v6_status) { 200 }
 


### PR DESCRIPTION
During a brief outage yesterday where the endpoint was returning 404s we experienced some surprising issues when our cache was invalidated and all callers to the rails app were having their remote_ip changing because the CF set was empty causing sessions invalidations.

Our team @wrapbook noticed something odd in the gem where the default config for `ip` isn't referenced in the application and seems like a reasonable approach to allow it to be used when either of the importers fails.

Thoughts?

cc @erichmachado 