### PR TITLE
Update gemspec to allow for Rails 7.2.0 + main

### DIFF
--- a/cloudflare-rails.gemspec
+++ b/cloudflare-rails.gemspec
@@ -31,9 +31,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec', '~> 2.26.1'
   spec.add_development_dependency 'webmock', '~> 3.19.1'
 
-  spec.add_dependency 'actionpack', '>= 6.1', '< 7.2.0'
-  spec.add_dependency 'activesupport', '>= 6.1', '< 7.2.0'
-  spec.add_dependency 'railties', '>= 6.1', '< 7.2.0'
+  spec.add_dependency 'actionpack', '>= 6.1'
+  spec.add_dependency 'activesupport', '>= 6.1'
+  spec.add_dependency 'railties', '>= 6.1'
   spec.add_dependency 'zeitwerk', '>= 2.5.0'
 
   # rails 6.1 lists this as the minimum


### PR DESCRIPTION
Followup to #116 

Rails 7.2.0 is about to be released, and I've tested this gem on Rails 7.2.0 ( stable branch) in a production app, with success ( I've encoutered no issues, the caching mechanism works, and the remote IP works)

Also for those who are on rails main, it would be better to not lock the version, and if needed people can submit fixes in the future if there are any issues encountered, rather than forking the repo.

EDIT: if this is something that you may accept, please let me know, and I will further update this PR to add more checks on rails main + rails 7.2.0 etc..

EDIT2: there is already an Appraisal on rails main branch, added in #116 . **I think we can merge this PR**
Thanks!